### PR TITLE
Add issue templates, support routing, and a triage label set

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,88 @@
+name: 🐞 Bug report
+description: Something in the Mod Manager or Mod Editor isn't working right.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! A little detail here saves a lot of back-and-forth.
+        **Before you start:** please make sure you're on the latest version (click **Check for IMM Update**) — a lot of bugs are already fixed.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before submitting
+      options:
+        - label: I'm on the latest version (checked via "Check for IMM Update").
+          required: true
+        - label: I searched existing issues and this isn't a duplicate.
+          required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Which part?
+      description: Where does the problem happen?
+      options:
+        - Mod Manager (IMM)
+        - Mod Editor
+        - Downloading mods / updating the database
+        - Merging mods / merge options
+        - Installed mods / in-game behavior
+        - Not sure
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Mod Manager / Editor version
+      description: Shown in the title bar (e.g. "2.4.9"). The DebugLog also lists it.
+      placeholder: "2.4.9"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows 11
+        - Windows 10
+        - Linux (Wine / Proton)
+        - Other (say which in the description)
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What went wrong, and what did you expect instead?
+      placeholder: When I click X, Y happens. I expected Z.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: The exact steps so it can be reproduced.
+      placeholder: |
+        1. Open IMM
+        2. Click '...'
+        3. See the error
+    validations:
+      required: true
+  - type: textarea
+    id: debuglog
+    attributes:
+      label: DebugLog.txt
+      description: |
+        In IMM click **Create Debug Log File**, then open `DebugLog.txt` from the install folder and paste its contents here.
+        This is the single most useful thing for diagnosing a bug.
+      render: text
+    validations:
+      required: false
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If it's a UI or error-popup issue, drag images in here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+# Blank issues are disabled so usage/how-to questions are routed to support
+# channels instead of the bug tracker. Flip this to `true` if you'd rather
+# keep the "Open a blank issue" option.
+blank_issues_enabled: false
+contact_links:
+  - name: 📺 How to install & use mods (instruction video)
+    url: https://youtu.be/-4DFoDnSBJ4
+    about: New to the Mod Manager? Watch this first — it covers setup, downloading and installing mods.
+  - name: 💬 Questions & help (Discord)
+    url: https://discord.gg/ZevBpxxGyg
+    about: For "how do I…" questions, setup help, and general chat. Please ask here instead of opening an issue.
+  - name: 📖 Read the changelog / README
+    url: https://github.com/Jimk72/Icarus_Software/blob/main/README.md
+    about: Recent fixes and version notes — your problem may already be addressed in a newer version.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,46 @@
+name: 💡 Feature request
+description: Suggest a new feature or an improvement.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this hasn't already been requested.
+          required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Which part?
+      options:
+        - Mod Manager (IMM)
+        - Mod Editor
+        - Downloads / database
+        - Merge options
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: What are you trying to do that's hard or impossible today?
+      placeholder: "When I'm managing lots of mods, I can't easily…"
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like to see?
+      description: Describe the feature or change.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Anything else?
+      description: Alternatives you've considered, mockups, examples from other tools, etc.
+    validations:
+      required: false

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,51 @@
+# Label definitions for Icarus_Software.
+# Add-only: your existing default labels (bug, enhancement, question, etc.) are
+# kept. Run the "Sync labels" workflow (Actions tab) to create/update these.
+# Colors are 6-digit hex without the leading '#'.
+
+# --- Area: which part of the software ---
+- name: "area: mod manager"
+  color: "1d76db"
+  description: "The Mod Manager app (IMM) itself"
+- name: "area: mod editor"
+  color: "1d76db"
+  description: "The Mod Editor"
+- name: "area: downloads & database"
+  color: "1d76db"
+  description: "Downloading mods, updating the database, repos.json/mods.json"
+- name: "area: merge"
+  color: "1d76db"
+  description: "Merging mods, merge options, the merged output"
+- name: "area: mod content"
+  color: "1d76db"
+  description: "A specific mod's content or behavior (often author-side)"
+
+# --- Type / triage ---
+- name: "crash"
+  color: "b60205"
+  description: "Access violation or hard crash"
+- name: "support"
+  color: "5319e7"
+  description: "How-to / usage help rather than a code defect"
+- name: "needs info"
+  color: "fbca04"
+  description: "Waiting on more details from the reporter"
+- name: "needs repro"
+  color: "fbca04"
+  description: "Can't reproduce yet — needs steps"
+- name: "upstream"
+  color: "d4c5f9"
+  description: "Root cause is the game/data or an external host, not IMM"
+- name: "translation / non-english"
+  color: "006b75"
+  description: "Report is in another language or is a localization issue"
+
+# --- Platform ---
+- name: "platform: linux"
+  color: "c5def5"
+  description: "Linux / Wine / Proton"
+
+# --- Priority ---
+- name: "priority: high"
+  color: "e11d21"
+  description: "Should be looked at soon"

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,22 @@
+name: Sync labels
+
+# Manual-only: nothing runs automatically. Go to the Actions tab, pick
+# "Sync labels", and click "Run workflow" to create/update the labels
+# defined in .github/labels.yml. It does NOT delete your existing labels.
+on:
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yml
+          delete-other-labels: false
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hey Jim — small quality-of-life contribution to help manage the issue tracker. All additive, nothing existing is touched.

**What's in here (all under `.github/`):**

- **`ISSUE_TEMPLATE/bug_report.yml`** — a structured bug form that asks for version, OS, which part (Mod Manager / Editor / Downloads / Merge / in-game), repro steps, and — most usefully — a **DebugLog.txt** paste field. Should cut down the back-and-forth on reports that arrive with no version or log.
- **`ISSUE_TEMPLATE/feature_request.yml`** — a simple feature-request form.
- **`ISSUE_TEMPLATE/config.yml`** — routes "how do I install/download mods?" type questions to the Discord, the instruction video, and the README **instead of** the bug tracker. It sets `blank_issues_enabled: false`; if you'd rather keep the blank-issue option, just flip that one line to `true`.
- **`labels.yml` + `workflows/labels.yml`** — a triage label set (area / type / platform / priority) on top of your existing default labels. It's **add-only** (won't delete or rename anything you have). To create them: **Actions tab → "Sync labels" → Run workflow** (it only runs when you click it — nothing runs automatically).

**Labels it adds:** `area: mod manager`, `area: mod editor`, `area: downloads & database`, `area: merge`, `area: mod content`, `crash`, `support`, `needs info`, `needs repro`, `upstream`, `translation / non-english`, `platform: linux`, `priority: high`.

Totally fine to cherry-pick — take the templates and skip the labels, or vice-versa. 👍
